### PR TITLE
Add asset registry governance

### DIFF
--- a/assets/asset-registry.json
+++ b/assets/asset-registry.json
@@ -1,0 +1,131 @@
+{
+  "version": 1,
+  "collections": [
+    {
+      "id": "process-event-templates",
+      "domain": "process",
+      "purpose": "event-template-download",
+      "canonical": true,
+      "compatibilityNote": "Canonical process templates referenced as a collection from process/index.md.",
+      "assets": [
+        "process/assets/event-templates/活动策划书.docx",
+        "process/assets/event-templates/第二课堂申报表.doc",
+        "process/assets/event-templates/计算机协会 志愿者招募.docx"
+      ]
+    },
+    {
+      "id": "process-repair-day-templates",
+      "domain": "process",
+      "purpose": "repair-day-template-download",
+      "canonical": true,
+      "compatibilityNote": "Canonical repair-day template set. Legacy Chinese paths mirror these files for compatibility and should not be used by new links.",
+      "assets": [
+        "process/assets/repair-day-templates/理工维修日志愿者活动总结表.docx",
+        "process/assets/repair-day-templates/注意事项.docx",
+        "process/assets/repair-day-templates/202X.X.X理工维修日签到表.xlsx",
+        "process/assets/repair-day-templates/202X.X.X理工维修日.xlsx",
+        "process/assets/repair-day-templates/理工维修日志愿者活动申请表.docx",
+        "process/assets/repair-day-templates/组织委员会议/1.个人申报志愿者活动材料/志愿者活动总结表.docx",
+        "process/assets/repair-day-templates/组织委员会议/1.个人申报志愿者活动材料/活动名称+时长.xlsx",
+        "process/assets/repair-day-templates/组织委员会议/1.个人申报志愿者活动材料/注意事项.docx",
+        "process/assets/repair-day-templates/组织委员会议/1.个人申报志愿者活动材料/志愿者活动申请表.docx",
+        "process/assets/repair-day-templates/组织委员会议/2.班级申报志愿者活动材料/xx班级-xx志愿者活动志愿者情况汇总表.xlsx",
+        "process/assets/repair-day-templates/组织委员会议/2.班级申报志愿者活动材料/数据学院班级志愿者活动申报表.docx",
+        "process/assets/repair-day-templates/组织委员会议/2.班级申报志愿者活动材料/数据学院班级自主申报志愿者活动方案（试行）.docx",
+        "process/assets/repair-day-templates/组织委员会议/3.社团及实验室申报志愿者活动材料/社团及实验室自主申报志愿者活动材料/数据学院各类社团及实验室志愿者时长管理细则.docx",
+        "process/assets/repair-day-templates/组织委员会议/3.社团及实验室申报志愿者活动材料/社团及实验室自主申报志愿者活动材料/数据学院社团及实验室志愿者活动申报表.docx",
+        "process/assets/repair-day-templates/组织委员会议/3.社团及实验室申报志愿者活动材料/社团及实验室自主申报志愿者活动材料/活动相关情况记录.xlsx",
+        "process/assets/repair-day-templates/组织委员会议/4.志愿者时长统计材料/数据学院青年志愿者协会志愿时长线上认证规定.docx",
+        "process/assets/repair-day-templates/组织委员会议/4.志愿者时长统计材料/xxx班-志愿时长汇总材料/xxx班-志愿者时长汇总表.xlsx",
+        "process/assets/repair-day-templates/组织委员会议/4.志愿者时长统计材料/xxx班-志愿时长汇总材料/个人志愿者时长汇总材料/应佩钰-志愿者时长汇总材料/志愿时长汇总表.xlsx",
+        "process/assets/repair-day-templates/组织委员会议/4.志愿者时长统计材料/xxx班-志愿时长汇总材料/个人志愿者时长汇总材料/应佩钰-志愿者时长汇总材料/时长证明材料汇总/2020.10.7-我爱微积分活动.png",
+        "process/assets/repair-day-templates/组织委员会议/4.志愿者时长统计材料/xxx班-志愿时长汇总材料/个人志愿者时长汇总材料/张三-志愿者时长汇总材料/张三-志愿时长认证.xlsx",
+        "process/assets/repair-day-templates/组织委员会议/5.组织委员大会内容重点摘要.docx"
+      ]
+    },
+    {
+      "id": "legacy-repair-day-template-mirror",
+      "domain": "legacy-repair-day",
+      "purpose": "legacy-template-download",
+      "canonical": false,
+      "legacyRoot": "维修日/理工维修日活动申请文件模板",
+      "canonicalRoot": "process/assets/repair-day-templates",
+      "compatibilityNote": "Legacy Chinese path mirror retained for existing inbound links and manual file lookup. Prefer canonical process/assets/repair-day-templates paths for new content.",
+      "assets": [
+        "维修日/理工维修日活动申请文件模板/理工维修日志愿者活动总结表.docx",
+        "维修日/理工维修日活动申请文件模板/注意事项.docx",
+        "维修日/理工维修日活动申请文件模板/202X.X.X理工维修日签到表.xlsx",
+        "维修日/理工维修日活动申请文件模板/202X.X.X理工维修日.xlsx",
+        "维修日/理工维修日活动申请文件模板/理工维修日志愿者活动申请表.docx",
+        "维修日/理工维修日活动申请文件模板/组织委员会议/1.个人申报志愿者活动材料/志愿者活动总结表.docx",
+        "维修日/理工维修日活动申请文件模板/组织委员会议/1.个人申报志愿者活动材料/活动名称+时长.xlsx",
+        "维修日/理工维修日活动申请文件模板/组织委员会议/1.个人申报志愿者活动材料/注意事项.docx",
+        "维修日/理工维修日活动申请文件模板/组织委员会议/1.个人申报志愿者活动材料/志愿者活动申请表.docx",
+        "维修日/理工维修日活动申请文件模板/组织委员会议/2.班级申报志愿者活动材料/xx班级-xx志愿者活动志愿者情况汇总表.xlsx",
+        "维修日/理工维修日活动申请文件模板/组织委员会议/2.班级申报志愿者活动材料/数据学院班级志愿者活动申报表.docx",
+        "维修日/理工维修日活动申请文件模板/组织委员会议/2.班级申报志愿者活动材料/数据学院班级自主申报志愿者活动方案（试行）.docx",
+        "维修日/理工维修日活动申请文件模板/组织委员会议/3.社团及实验室申报志愿者活动材料/社团及实验室自主申报志愿者活动材料/数据学院各类社团及实验室志愿者时长管理细则.docx",
+        "维修日/理工维修日活动申请文件模板/组织委员会议/3.社团及实验室申报志愿者活动材料/社团及实验室自主申报志愿者活动材料/数据学院社团及实验室志愿者活动申报表.docx",
+        "维修日/理工维修日活动申请文件模板/组织委员会议/3.社团及实验室申报志愿者活动材料/社团及实验室自主申报志愿者活动材料/活动相关情况记录.xlsx",
+        "维修日/理工维修日活动申请文件模板/组织委员会议/4.志愿者时长统计材料/数据学院青年志愿者协会志愿时长线上认证规定.docx",
+        "维修日/理工维修日活动申请文件模板/组织委员会议/4.志愿者时长统计材料/xxx班-志愿时长汇总材料/xxx班-志愿者时长汇总表.xlsx",
+        "维修日/理工维修日活动申请文件模板/组织委员会议/4.志愿者时长统计材料/xxx班-志愿时长汇总材料/个人志愿者时长汇总材料/应佩钰-志愿者时长汇总材料/志愿时长汇总表.xlsx",
+        "维修日/理工维修日活动申请文件模板/组织委员会议/4.志愿者时长统计材料/xxx班-志愿时长汇总材料/个人志愿者时长汇总材料/应佩钰-志愿者时长汇总材料/时长证明材料汇总/2020.10.7-我爱微积分活动.png",
+        "维修日/理工维修日活动申请文件模板/组织委员会议/4.志愿者时长统计材料/xxx班-志愿时长汇总材料/个人志愿者时长汇总材料/张三-志愿者时长汇总材料/张三-志愿时长认证.xlsx",
+        "维修日/理工维修日活动申请文件模板/组织委员会议/5.组织委员大会内容重点摘要.docx"
+      ]
+    },
+    {
+      "id": "repair-documentation-images",
+      "domain": "repair",
+      "purpose": "documentation-image",
+      "canonical": true,
+      "compatibilityNote": "Canonical screenshots used by repair/weekend.md.",
+      "assets": [
+        "repair/assets/issue-label.png",
+        "repair/assets/issue-reply-example.png",
+        "repair/assets/link-github.png"
+      ]
+    },
+    {
+      "id": "tutorial-documentation-images",
+      "domain": "tutorial",
+      "purpose": "documentation-image",
+      "canonical": true,
+      "compatibilityNote": "Canonical screenshots used by tutorial guides.",
+      "assets": [
+        "tutorial/assets/Approve.png",
+        "tutorial/assets/Assignees.png",
+        "tutorial/assets/Auto-Merge.png",
+        "tutorial/assets/Branch.png",
+        "tutorial/assets/Commit.png",
+        "tutorial/assets/Create-PR.png",
+        "tutorial/assets/Edit.png",
+        "tutorial/assets/Label-Setup.png",
+        "tutorial/assets/Merge.png",
+        "tutorial/assets/Minecraft-Server-Management.png",
+        "tutorial/assets/Minecraft-Wiki-git.png",
+        "tutorial/assets/Minecraft-Wiki-gh.png",
+        "tutorial/assets/Minecraft-Wiki.png",
+        "tutorial/assets/PR-Reviewer.png",
+        "tutorial/assets/Payment-information.png",
+        "tutorial/assets/Reviewer-PR.png",
+        "tutorial/assets/Roadmap.png",
+        "tutorial/assets/Subs.png",
+        "tutorial/assets/Success.png",
+        "tutorial/assets/gh-issue-list.png",
+        "tutorial/assets/gh-issue-view.png"
+      ]
+    },
+    {
+      "id": "archived-2017-workbooks",
+      "domain": "archived",
+      "purpose": "archive-record",
+      "canonical": true,
+      "compatibilityNote": "Historical workbook retained as an archived record; not a reusable template.",
+      "assets": [
+        "archived/2017/2017~2018星级评定评分汇总.xlsx"
+      ]
+    }
+  ]
+}

--- a/utils/asset-registry.test.ts
+++ b/utils/asset-registry.test.ts
@@ -1,0 +1,65 @@
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+import {
+  assetExists,
+  expandAssetRegistry,
+  groupEntriesByContentHash,
+  listTargetBinaryAssets,
+  loadAssetRegistry,
+} from './asset-registry'
+
+const repoRoot = path.resolve(__dirname, '..')
+const registry = loadAssetRegistry(repoRoot)
+const entries = expandAssetRegistry(registry)
+
+describe('asset registry', () => {
+  it('points every registered asset at an existing file', () => {
+    const missingAssets = entries
+      .filter(entry => !assetExists(entry.path, repoRoot))
+      .map(entry => entry.path)
+
+    expect(missingAssets).toEqual([])
+  })
+
+  it('registers every target binary asset in the repository', () => {
+    const actualAssets = new Set(listTargetBinaryAssets(repoRoot))
+    const registeredAssets = new Set(entries.map(entry => entry.path))
+
+    const unregisteredAssets = [...actualAssets].filter(asset => !registeredAssets.has(asset))
+    const staleRegistryAssets = [...registeredAssets].filter(asset => !actualAssets.has(asset))
+
+    expect(unregisteredAssets).toEqual([])
+    expect(staleRegistryAssets).toEqual([])
+  })
+
+  it('keeps asset paths and canonical paths unambiguous', () => {
+    const registeredPaths = entries.map(entry => entry.path)
+    const canonicalPaths = entries.filter(entry => entry.canonical).map(entry => entry.path)
+
+    expect(new Set(registeredPaths).size).toBe(registeredPaths.length)
+    expect(new Set(canonicalPaths).size).toBe(canonicalPaths.length)
+
+    for (const entry of entries.filter(entry => !entry.canonical)) {
+      expect(entry.canonicalPath).toBeTruthy()
+      expect(canonicalPaths).toContain(entry.canonicalPath)
+    }
+  })
+
+  it('requires duplicate hashes to have one canonical asset and explicit compatibility notes', () => {
+    const duplicateGroups = [...groupEntriesByContentHash(entries, repoRoot).values()]
+      .filter(group => group.length > 1)
+
+    for (const group of duplicateGroups) {
+      const canonicalEntries = group.filter(entry => entry.canonical)
+
+      expect(canonicalEntries).toHaveLength(1)
+
+      for (const entry of group) {
+        expect(entry.compatibilityNote.trim()).not.toBe('')
+
+        if (!entry.canonical)
+          expect(entry.canonicalPath).toBe(canonicalEntries[0].path)
+      }
+    }
+  })
+})

--- a/utils/asset-registry.ts
+++ b/utils/asset-registry.ts
@@ -1,0 +1,135 @@
+import { createHash } from 'node:crypto'
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+
+const repoRoot = path.resolve(__dirname, '..')
+const targetAssetExtensions = new Set(['.png', '.doc', '.docx', '.xlsx'])
+const ignoredDirectoryPaths = ['.git', 'node_modules', '.vitepress/dist', '.vitepress/cache']
+
+export interface AssetRegistryManifest {
+  version: number
+  collections: AssetRegistryCollection[]
+}
+
+export interface AssetRegistryCollection {
+  id: string
+  domain: string
+  purpose: string
+  canonical: boolean
+  compatibilityNote: string
+  legacyRoot?: string
+  canonicalRoot?: string
+  assets: AssetRegistryAsset[]
+}
+
+export interface AssetRegistryObjectAsset {
+  path: string
+  title?: string
+  canonicalPath?: string
+  notes?: string
+}
+
+export type AssetRegistryAsset = string | AssetRegistryObjectAsset
+
+export interface AssetRegistryEntry {
+  collectionId: string
+  path: string
+  domain: string
+  purpose: string
+  canonical: boolean
+  compatibilityNote: string
+  canonicalPath?: string
+  title?: string
+  notes?: string
+}
+
+export function loadAssetRegistry(rootDir = repoRoot): AssetRegistryManifest {
+  const registryPath = path.join(rootDir, 'assets/asset-registry.json')
+  return JSON.parse(readFileSync(registryPath, 'utf8')) as AssetRegistryManifest
+}
+
+export function expandAssetRegistry(manifest = loadAssetRegistry()): AssetRegistryEntry[] {
+  return manifest.collections.flatMap((collection) => {
+    return collection.assets.map((asset) => {
+      const assetEntry = typeof asset === 'string' ? { path: asset } : asset
+
+      return {
+        collectionId: collection.id,
+        path: assetEntry.path,
+        domain: collection.domain,
+        purpose: collection.purpose,
+        canonical: collection.canonical,
+        compatibilityNote: collection.compatibilityNote,
+        canonicalPath: assetEntry.canonicalPath ?? deriveCanonicalPath(collection, assetEntry.path),
+        title: assetEntry.title,
+        notes: assetEntry.notes,
+      }
+    })
+  })
+}
+
+export function listTargetBinaryAssets(rootDir = repoRoot): string[] {
+  const assets: string[] = []
+
+  function visit(directory: string) {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const absolutePath = path.join(directory, entry.name)
+      const repoPath = toRepoPath(absolutePath, rootDir)
+
+      if (entry.isDirectory()) {
+        if (!isIgnoredDirectory(repoPath))
+          visit(absolutePath)
+        continue
+      }
+
+      if (entry.isFile() && targetAssetExtensions.has(path.extname(entry.name).toLowerCase()))
+        assets.push(repoPath)
+    }
+  }
+
+  visit(rootDir)
+  return assets.sort((a, b) => a.localeCompare(b))
+}
+
+export function assetExists(assetPath: string, rootDir = repoRoot): boolean {
+  return existsSync(path.join(rootDir, assetPath))
+}
+
+export function hashAsset(assetPath: string, rootDir = repoRoot): string {
+  return createHash('sha256')
+    .update(readFileSync(path.join(rootDir, assetPath)))
+    .digest('hex')
+}
+
+export function groupEntriesByContentHash(entries: AssetRegistryEntry[], rootDir = repoRoot) {
+  const groups = new Map<string, AssetRegistryEntry[]>()
+
+  for (const entry of entries) {
+    const hash = hashAsset(entry.path, rootDir)
+    const group = groups.get(hash) ?? []
+    group.push(entry)
+    groups.set(hash, group)
+  }
+
+  return groups
+}
+
+function deriveCanonicalPath(collection: AssetRegistryCollection, assetPath: string): string | undefined {
+  if (collection.canonical || !collection.legacyRoot || !collection.canonicalRoot)
+    return undefined
+
+  if (!assetPath.startsWith(collection.legacyRoot))
+    return undefined
+
+  return `${collection.canonicalRoot}${assetPath.slice(collection.legacyRoot.length)}`
+}
+
+function isIgnoredDirectory(repoPath: string): boolean {
+  return ignoredDirectoryPaths.some((ignoredPath) => {
+    return repoPath === ignoredPath || repoPath.startsWith(`${ignoredPath}/`)
+  })
+}
+
+function toRepoPath(absolutePath: string, rootDir: string): string {
+  return path.relative(rootDir, absolutePath).split(path.sep).join('/')
+}


### PR DESCRIPTION
## Summary
- add a structured asset registry for binary templates, screenshots, and archived workbook assets
- mark process/assets repair-day templates as canonical and the legacy Chinese directory as compatibility duplicates
- add registry tests for file existence, full binary asset coverage, canonical path uniqueness, and duplicate hash disclosure

## Verification
- pnpm test -- --run
- pnpm run ci:lint
- pnpm docs:build

## Notes
No binary assets were deleted. The audit found 21 duplicate hash groups across the canonical repair-day templates and legacy Chinese mirror.