### PR TITLE
Add content contract site tests

### DIFF
--- a/utils/content-contract.test.ts
+++ b/utils/content-contract.test.ts
@@ -1,0 +1,132 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  collectNavigationLinks,
+  extractH1,
+  extractMarkdownLinks,
+  findDuplicateRoutePaths,
+  listActiveDocs,
+  listArchivedDocs,
+  resolveInternalLink,
+  routePathFromRelativePath,
+} from '../utils/content-contract'
+
+let tempDir: string | undefined
+
+afterEach(() => {
+  if (tempDir)
+    rmSync(tempDir, { force: true, recursive: true })
+  tempDir = undefined
+})
+
+describe('content contract', () => {
+  it('classifies active and archived document trees separately', () => {
+    tempDir = mkdtempSync(path.join(tmpdir(), 'content-contract-'))
+    writeFixture('tutorial/index.md', '# Tutorial')
+    writeFixture('process/2025/example.md', '# Process')
+    writeFixture('repair/guide.md', '# Repair')
+    writeFixture('archived/2025/meeting.md', '# Meeting')
+
+    expect(listActiveDocs(tempDir).map(doc => doc.relativePath)).toEqual([
+      'process/2025/example.md',
+      'repair/guide.md',
+      'tutorial/index.md',
+    ])
+    expect(listArchivedDocs(tempDir).map(doc => doc.relativePath)).toEqual([
+      'archived/2025/meeting.md',
+    ])
+  })
+
+  it('extracts the first prose H1 and ignores fenced code', () => {
+    const title = extractH1([
+      '```sh',
+      '# not a heading',
+      '```',
+      '',
+      '# Real heading',
+    ].join('\n'))
+
+    expect(title).toBe('Real heading')
+  })
+
+  it('generates stable VitePress route paths from markdown files', () => {
+    expect(routePathFromRelativePath('tutorial/2025/example.md')).toBe('/tutorial/2025/example')
+    expect(routePathFromRelativePath('repair/guide.md')).toBe('/repair/guide')
+  })
+
+  it('detects duplicate route paths', () => {
+    const duplicateRoutes = findDuplicateRoutePaths([
+      docFixture('tutorial/guide.md', '/tutorial/guide'),
+      docFixture('process/guide.md', '/process/guide'),
+      docFixture('repair/guide.md', '/tutorial/guide'),
+    ])
+
+    expect(duplicateRoutes).toEqual([
+      {
+        files: ['tutorial/guide.md', 'repair/guide.md'],
+        routePath: '/tutorial/guide',
+      },
+    ])
+  })
+
+  it('collects nav and sidebar links with nested bases', () => {
+    const links = collectNavigationLinks({
+      themeConfig: {
+        nav: [{ link: '/tutorial/' }],
+        sidebar: {
+          '/tutorial/': [
+            {
+              base: '/tutorial/2025/',
+              items: [
+                { link: 'example' },
+              ],
+            },
+          ],
+        },
+      },
+    })
+
+    expect(links).toEqual([
+      '/tutorial/2025/example',
+      '/tutorial/index',
+    ])
+  })
+
+  it('resolves internal document and asset links', () => {
+    tempDir = mkdtempSync(path.join(tmpdir(), 'content-contract-links-'))
+    writeFixture('tutorial/index.md', '# Tutorial\n[Asset](./assets/example.png)\n[Repair](/repair/guide)')
+    writeFixture('tutorial/assets/example.png', '')
+    writeFixture('repair/guide.md', '# Repair')
+
+    const links = extractMarkdownLinks(
+      '# Tutorial\n[Asset](./assets/example.png)\n[Repair](/repair/guide)',
+      'tutorial/index.md',
+    )
+    const resolutions = links.map(link => resolveInternalLink(link, tempDir))
+
+    expect(resolutions.map(resolution => resolution.status)).toEqual(['ok', 'ok'])
+  })
+})
+
+function writeFixture(relativePath: string, content: string): void {
+  if (!tempDir)
+    throw new Error('tempDir must be initialized before writing fixtures')
+
+  const absolutePath = path.join(tempDir, relativePath)
+  mkdirSync(path.dirname(absolutePath), { recursive: true })
+  writeFileSync(absolutePath, content)
+}
+
+function docFixture(relativePath: string, routePath: string) {
+  return {
+    absolutePath: `/tmp/${relativePath}`,
+    category: 'active' as const,
+    content: '# Fixture',
+    domain: relativePath.split('/')[0],
+    h1: 'Fixture',
+    relativePath,
+    routePath,
+  }
+}

--- a/utils/content-contract.ts
+++ b/utils/content-contract.ts
@@ -1,0 +1,367 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import path from 'node:path'
+
+export const ACTIVE_DOC_DIRS = ['tutorial', 'process', 'repair'] as const
+export const ARCHIVED_DOC_DIR = 'archived'
+
+export type ActiveDocDomain = typeof ACTIVE_DOC_DIRS[number]
+export type DocCategory = 'active' | 'archived'
+
+export interface DocFile {
+  absolutePath: string
+  category: DocCategory
+  content: string
+  domain: string
+  h1: string | undefined
+  relativePath: string
+  routePath: string
+}
+
+export interface MarkdownLink {
+  line: number
+  rawTarget: string
+  sourceRelativePath: string
+  target: string
+}
+
+export interface LinkResolution {
+  link: MarkdownLink
+  reason?: string
+  resolvedPath?: string
+  status: 'ok' | 'skipped' | 'broken'
+}
+
+export interface DuplicateRoute {
+  routePath: string
+  files: string[]
+}
+
+const DEFAULT_ROOT = path.resolve(__dirname, '..')
+export function toPosixPath(filepath: string): string {
+  return filepath.split(path.sep).join(path.posix.sep)
+}
+
+export function routePathFromRelativePath(relativePath: string): string {
+  return `/${toPosixPath(relativePath).replace(/\.md$/, '')}`
+}
+
+export function extractH1(content: string): string | undefined {
+  let inFence = false
+
+  for (const line of content.split(/\r?\n/)) {
+    const trimmedStart = line.trimStart()
+    if (isFenceMarker(trimmedStart)) {
+      inFence = !inFence
+      continue
+    }
+
+    if (inFence)
+      continue
+
+    if (line.startsWith('# ')) {
+      const heading = stripClosingHeadingMarkers(line.slice(2).trim())
+      if (heading)
+        return heading
+    }
+  }
+}
+
+export function listDocs(root = DEFAULT_ROOT): DocFile[] {
+  const docs: DocFile[] = []
+
+  for (const domain of ACTIVE_DOC_DIRS)
+    docs.push(...listDocsInDomain(root, domain, 'active'))
+
+  docs.push(...listDocsInDomain(root, ARCHIVED_DOC_DIR, 'archived'))
+
+  return docs.sort((a, b) => a.relativePath.localeCompare(b.relativePath))
+}
+
+export function listActiveDocs(root = DEFAULT_ROOT): DocFile[] {
+  return listDocs(root).filter(doc => doc.category === 'active')
+}
+
+export function listArchivedDocs(root = DEFAULT_ROOT): DocFile[] {
+  return listDocs(root).filter(doc => doc.category === 'archived')
+}
+
+export function findDuplicateRoutePaths(docs: DocFile[]): DuplicateRoute[] {
+  const byRoute = new Map<string, string[]>()
+
+  for (const doc of docs) {
+    const files = byRoute.get(doc.routePath) ?? []
+    files.push(doc.relativePath)
+    byRoute.set(doc.routePath, files)
+  }
+
+  return [...byRoute.entries()]
+    .filter(([, files]) => files.length > 1)
+    .map(([routePath, files]) => ({ routePath, files }))
+}
+
+export function extractMarkdownLinks(content: string, sourceRelativePath: string): MarkdownLink[] {
+  const links: MarkdownLink[] = []
+  const lines = content.split(/\r?\n/)
+  let inFence = false
+
+  for (const [index, line] of lines.entries()) {
+    const trimmedStart = line.trimStart()
+    if (isFenceMarker(trimmedStart)) {
+      inFence = !inFence
+      continue
+    }
+
+    if (inFence)
+      continue
+
+    let searchFrom = 0
+    while (searchFrom < line.length) {
+      const targetStart = line.indexOf('](', searchFrom)
+      if (targetStart < 0)
+        break
+
+      const targetEnd = line.indexOf(')', targetStart + 2)
+      if (targetEnd < 0)
+        break
+
+      const rawTarget = line.slice(targetStart + 2, targetEnd)
+      const target = cleanMarkdownTarget(rawTarget)
+      links.push({
+        line: index + 1,
+        rawTarget,
+        sourceRelativePath,
+        target,
+      })
+      searchFrom = targetEnd + 1
+    }
+  }
+
+  return links
+}
+
+function isFenceMarker(trimmedStart: string): boolean {
+  return trimmedStart.startsWith('```') || trimmedStart.startsWith('~~~')
+}
+
+function stripClosingHeadingMarkers(heading: string): string {
+  let end = heading.length
+  while (end > 0 && heading[end - 1] === '#')
+    end -= 1
+
+  if (end < heading.length && end > 0 && /\s/.test(heading[end - 1]))
+    return heading.slice(0, end).trimEnd()
+
+  return heading
+}
+
+export function resolveInternalLink(link: MarkdownLink, root = DEFAULT_ROOT): LinkResolution {
+  if (!link.target || isExternalLink(link.target) || link.target.startsWith('#')) {
+    return {
+      link,
+      reason: 'external or same-page anchor',
+      status: 'skipped',
+    }
+  }
+
+  const targetPath = stripHashAndQuery(link.target)
+  if (!targetPath) {
+    return {
+      link,
+      reason: 'same-page anchor',
+      status: 'skipped',
+    }
+  }
+
+  const decodedTargetPath = decodeLinkPath(targetPath)
+  const sourceDir = path.posix.dirname(toPosixPath(link.sourceRelativePath))
+  const candidatePath = decodedTargetPath.startsWith('/')
+    ? path.join(root, decodedTargetPath)
+    : path.resolve(root, sourceDir, decodedTargetPath)
+  const resolvedPath = resolveExistingPath(candidatePath)
+
+  if (resolvedPath) {
+    return {
+      link,
+      resolvedPath,
+      status: 'ok',
+    }
+  }
+
+  return {
+    link,
+    reason: `No file or VitePress page found for ${link.target}`,
+    status: 'broken',
+  }
+}
+
+export function collectNavigationLinks(config: unknown): string[] {
+  const links = new Set<string>()
+
+  if (!isRecord(config))
+    return []
+
+  const themeConfig = config.themeConfig
+  if (!isRecord(themeConfig))
+    return []
+
+  collectEntryLinks(themeConfig.nav, '', links)
+  collectEntryLinks(themeConfig.sidebar, '', links)
+
+  return [...links].sort()
+}
+
+export function normalizeSiteRoute(link: string): string | undefined {
+  if (!link || isExternalLink(link) || link.startsWith('#'))
+    return undefined
+
+  const withoutHash = stripHashAndQuery(link)
+  if (!withoutHash)
+    return undefined
+
+  let route = withoutHash
+  if (!route.startsWith('/'))
+    route = `/${route}`
+
+  route = route.replace(/\.md$/, '')
+  if (route.endsWith('/'))
+    route = `${route}index`
+
+  return path.posix.normalize(route)
+}
+
+function listDocsInDomain(root: string, domain: string, category: DocCategory): DocFile[] {
+  const domainDir = path.join(root, domain)
+  return listMarkdownFiles(domainDir).map((absolutePath) => {
+    const relativePath = toPosixPath(path.relative(root, absolutePath))
+    const content = readFileSync(absolutePath, 'utf-8')
+
+    return {
+      absolutePath,
+      category,
+      content,
+      domain,
+      h1: extractH1(content),
+      relativePath,
+      routePath: routePathFromRelativePath(relativePath),
+    }
+  })
+}
+
+function listMarkdownFiles(dir: string): string[] {
+  if (!existsSync(dir))
+    return []
+
+  const files: string[] = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith('.'))
+      continue
+
+    const entryPath = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...listMarkdownFiles(entryPath))
+      continue
+    }
+
+    if (entry.isFile() && entry.name.endsWith('.md'))
+      files.push(entryPath)
+  }
+
+  return files.sort()
+}
+
+function cleanMarkdownTarget(rawTarget: string): string {
+  const trimmed = rawTarget.trim()
+  if (!trimmed)
+    return ''
+
+  if (trimmed.startsWith('<')) {
+    const closing = trimmed.indexOf('>')
+    if (closing > 0)
+      return trimmed.slice(1, closing)
+  }
+
+  const titleStart = trimmed.search(/\s+["'(]/)
+  if (titleStart >= 0)
+    return trimmed.slice(0, titleStart)
+
+  return trimmed
+}
+
+function isExternalLink(target: string): boolean {
+  return /^[a-z][a-z\d+.-]*:/i.test(target) || target.startsWith('//')
+}
+
+function stripHashAndQuery(target: string): string {
+  const hashIndex = target.indexOf('#')
+  const queryIndex = target.indexOf('?')
+  const endIndex = [hashIndex, queryIndex]
+    .filter(index => index >= 0)
+    .sort((a, b) => a - b)[0]
+
+  return endIndex === undefined ? target : target.slice(0, endIndex)
+}
+
+function decodeLinkPath(target: string): string {
+  try {
+    return decodeURI(target)
+  }
+  catch {
+    return target
+  }
+}
+
+function resolveExistingPath(candidatePath: string): string | undefined {
+  if (existsSync(candidatePath)) {
+    if (statSync(candidatePath).isDirectory())
+      return existingPath(path.join(candidatePath, 'index.md'))
+
+    return candidatePath
+  }
+
+  return existingPath(`${candidatePath}.md`)
+    ?? existingPath(path.join(candidatePath, 'index.md'))
+}
+
+function existingPath(candidatePath: string): string | undefined {
+  return existsSync(candidatePath) ? candidatePath : undefined
+}
+
+function collectEntryLinks(value: unknown, base: string, links: Set<string>): void {
+  if (Array.isArray(value)) {
+    for (const item of value)
+      collectEntryLinks(item, base, links)
+    return
+  }
+
+  if (!isRecord(value))
+    return
+
+  const nextBase = typeof value.base === 'string'
+    ? resolveEntryLink(value.base, base)
+    : base
+
+  if (typeof value.link === 'string') {
+    const route = normalizeSiteRoute(resolveEntryLink(value.link, nextBase))
+    if (route)
+      links.add(route)
+  }
+
+  if ('items' in value)
+    collectEntryLinks(value.items, nextBase, links)
+
+  if (!('items' in value) && !('link' in value)) {
+    for (const child of Object.values(value))
+      collectEntryLinks(child, nextBase, links)
+  }
+}
+
+function resolveEntryLink(link: string, base: string): string {
+  if (link.startsWith('/'))
+    return link
+
+  return path.posix.join(base || '/', link)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}

--- a/utils/site.test.ts
+++ b/utils/site.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import siteConfig from '../.vitepress/config'
+import {
+  ACTIVE_DOC_DIRS,
+  collectNavigationLinks,
+  extractMarkdownLinks,
+  findDuplicateRoutePaths,
+  listActiveDocs,
+  resolveInternalLink,
+} from '../utils/content-contract'
+
+const activeDocs = listActiveDocs()
+const navigationLinks = new Set(collectNavigationLinks(siteConfig))
+
+describe('site content contract', () => {
+  it('extracts an H1 from every active document', () => {
+    const missingH1 = activeDocs
+      .filter(doc => !doc.h1)
+      .map(doc => doc.relativePath)
+
+    expect(missingH1).toEqual([])
+  })
+
+  it('generates unique site routes for active documents', () => {
+    const invalidRoutes = activeDocs
+      .filter(doc => !isActiveRoute(doc.routePath) || doc.routePath.includes('\\') || doc.routePath.endsWith('.md'))
+      .map(doc => `${doc.relativePath} -> ${doc.routePath}`)
+
+    expect(invalidRoutes).toEqual([])
+    expect(findDuplicateRoutePaths(activeDocs)).toEqual([])
+  })
+
+  it('exposes every active document through nav or sidebar entries', () => {
+    const missingEntries = activeDocs
+      .filter(doc => !navigationLinks.has(doc.routePath))
+      .map(doc => `${doc.relativePath} -> ${doc.routePath}`)
+
+    expect(missingEntries).toEqual([])
+  })
+
+  it('resolves internal links from active documents to existing files or assets', () => {
+    const brokenLinks = activeDocs.flatMap((doc) => {
+      return extractMarkdownLinks(doc.content, doc.relativePath)
+        .map(link => resolveInternalLink(link))
+        .filter(resolution => resolution.status === 'broken')
+        .map(resolution => `${doc.relativePath}:${resolution.link.line} -> ${resolution.link.target}`)
+    })
+
+    expect(brokenLinks).toEqual([])
+  })
+})
+
+function isActiveRoute(routePath: string): boolean {
+  return ACTIVE_DOC_DIRS.some(domain => routePath.startsWith(`/${domain}/`))
+}


### PR DESCRIPTION
## Summary
- add a content contract module that classifies active docs and archived docs
- verify active docs have extractable H1s, stable unique routes, nav/sidebar exposure, and resolvable internal links
- keep archived docs relaxed and do not evaluate content compliance wording

## Verification
- pnpm test -- --run
- pnpm run ci:lint
- pnpm docs:build