### PR TITLE
Ignore local preview artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ node_modules
 .vitepress/cache
 .vitepress/dist
 docs/
+
+# Local preview and browser automation artifacts
+.playwright-mcp/
+/nbtca-documents-preview*.png


### PR DESCRIPTION
## Summary
- Ignore Playwright MCP local output
- Ignore root-level nbtca-documents preview screenshots

## Verification
- git status --short
- git check-ignore -v .playwright-mcp/session.json nbtca-documents-preview-archived.png
- git check-ignore -v tutorial/assets/Approve.png repair/assets/issue-label.png

Lint not run: node_modules is not present in this worktree.