### PR TITLE
Improve docs preview preflight

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "vitest",
     "docs:dev": "vitepress dev",
     "docs:build": "vitepress build",
-    "docs:preview": "vitepress preview",
+    "docs:preview": "node scripts/docs-preview.mjs",
     "lint:markdown": "markdownlint-cli2 --fix --config .markdownlint-cli2.jsonc",
     "lint:eslint": "eslint --fix",
     "lint": "pnpm run '/^lint:.*/'",

--- a/scripts/docs-preview.mjs
+++ b/scripts/docs-preview.mjs
@@ -1,0 +1,36 @@
+import { spawn } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import process from 'node:process'
+
+const previewEntry = '.vitepress/dist/404.html'
+
+if (!existsSync(previewEntry)) {
+  console.error(`Cannot preview docs because ${previewEntry} does not exist.`)
+  console.error('Run `pnpm docs:build` first, then retry `pnpm docs:preview`.')
+  process.exit(1)
+}
+
+const args = process.argv.slice(2)
+
+if (args[0] === '--') {
+  args.shift()
+}
+
+const child = spawn('vitepress', ['preview', ...args], {
+  stdio: 'inherit',
+  shell: process.platform === 'win32',
+})
+
+child.on('error', (error) => {
+  console.error(error.message)
+  process.exit(1)
+})
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal)
+    return
+  }
+
+  process.exit(code ?? 0)
+})


### PR DESCRIPTION
## Summary
- add a small docs preview wrapper that checks for .vitepress/dist/404.html before starting VitePress
- keep VitePress preview behavior and CLI argument forwarding when the build output exists

## Verification
- pnpm docs:preview
- pnpm docs:build
- pnpm docs:preview -- --host 127.0.0.1 --port 4187
- pnpm run ci:lint
- pnpm test -- --run