### PR TITLE
fix(tooling): track docs/ and stop publishing governance docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,9 @@ updates:
     # Check the npm registry for updates every day (weekdays)
     schedule:
       interval: weekly
+
+  # Enable version updates for GitHub Actions used in workflows
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 node_modules
 .vitepress/cache
 .vitepress/dist
-docs/
 
 # Local preview and browser automation artifacts
 .playwright-mcp/

--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -40,6 +40,15 @@ export default withMermaid({
   ignoreDeadLinks: [
     /^https?:\/\//,
   ],
+  // Repo-governance docs are tracked in git but must not be published as
+  // site pages (they would otherwise leak into search and the sitemap as
+  // orphan pages with no navigation entry).
+  srcExclude: [
+    'README.md',
+    'CONTRIBUTING.md',
+    'CONTEXT.md',
+    'docs/**',
+  ],
   lastUpdated: true,
   sitemap: { hostname: 'https://docs.nbtca.space' },
 })

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Documents for nbtca",
   "license": "ISC",
   "engines": {
-    "node": "22.21.1",
+    "node": "^22",
     "pnpm": "9.0.0"
   },
   "scripts": {


### PR DESCRIPTION
## 概述（中文）

修复审查中发现的几个构建和工具配置问题，不改动任何文档内容。

- **ADR 没被纳入版本管理。** `.gitignore` 把整个 `docs/` 排除了，可 ADR 恰恰放在 `docs/adr/` 下，于是新写的 ADR 不会被 Git 跟踪，提交时悄悄漏掉——这正好违反了 ADR 0001 自己定的治理规则。现在删掉这条忽略规则。
- **几份治理文件混进了站点。** `README.md`、`CONTRIBUTING.md`、`CONTEXT.md` 以及 `docs/` 下的内容都被 VitePress 当成普通页面构建，会出现在站点地图和搜索结果里，可侧边栏和导航又都没有它们的入口，读者根本点不到。现在用 `srcExclude` 把它们排除在站点之外——文件仍留在仓库里，只是不再发布。
- **Node 版本限制得太死。** `engines.node` 写成了精确的 `22.21.1`，凡是用别的 22.x 版本的人都会反复收到 `Unsupported engine` 警告。放宽成 `^22`。
- **Dependabot 没盯着 Actions。** 之前只升级 npm 依赖，工作流里 `actions/checkout` 这类 Action 的版本一直没人更新。现在补上 `github-actions`。

本地已用 `ci:lint`、`test --run`、`docs:build` 验证通过，并确认构建结果里不再有那几个治理页面。

---

## Summary (English)

Fixes a few build and tooling config problems from the audit. No documentation content changes.

- **ADRs weren't under version control.** `.gitignore` excluded all of `docs/`, but ADRs sit in `docs/adr/`, so new ones were never committed — quietly dropped, against the very governance rules ADR 0001 sets out. The ignore rule is now removed.
- **Several governance files leaked into the site.** `README.md`, `CONTRIBUTING.md`, `CONTEXT.md` and the `docs/` tree were all built by VitePress as regular pages — they showed up in the sitemap and search, yet no sidebar or nav linked to them, so readers couldn't actually reach them. `srcExclude` now keeps them out of the site; they stay in the repo, just unpublished.
- **The Node constraint was too tight.** `engines.node` was the exact `22.21.1`, so anyone on a different 22.x kept getting `Unsupported engine` warnings. Loosened to `^22`.
- **Dependabot wasn't watching Actions.** It only bumped npm dependencies, leaving workflow actions like `actions/checkout` to go stale. Added `github-actions`.

Verified locally with `ci:lint`, `test --run` and `docs:build`, and confirmed those governance pages are gone from the build.

## Scope

- [x] CI or tooling
- [x] Governance docs

## Verification

- [x] `pnpm run ci:lint`
- [x] `pnpm test -- --run`
- [x] `pnpm docs:build`

Closes #121